### PR TITLE
Detected that custom integration 'pollen_dk' accesses hass.helpers.discovery. This is deprecated and will stop working in Home Assistant 2025.5

### DIFF
--- a/custom_components/pollen_dk/__init__.py
+++ b/custom_components/pollen_dk/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import logging
+from homeassistant.helpers.discovery import async_load_platform  # Import correct function
 
 from .pollen_dk_api import Pollen_DK
-
 from .const import (
     DOMAIN,
     CONF_CLIENT,
@@ -17,7 +17,6 @@ from .const import (
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 _LOGGER = logging.getLogger(__name__)
 
-
 async def async_setup(hass, config):
     # Get the configuration
     conf = config.get(DOMAIN)
@@ -25,6 +24,7 @@ async def async_setup(hass, config):
     if conf is None:
         return True
 
+    
     regionIDs = []
     regions = config[DOMAIN].get(CONF_REGIONS, [])
     if regions:
@@ -34,8 +34,9 @@ async def async_setup(hass, config):
                     regionIDs.append(regionID)
     else:
         regionIDs = REGION_IDS.values()
-    _LOGGER.debug(f"Region IDs loaded from config: { regionIDs }")
+    _LOGGER.debug(f"Region IDs loaded from config: {regionIDs}")
 
+    
     pollenIDs = []
     pollens = config[DOMAIN].get(CONF_POLLEN_TYPES, [])
     if pollens:
@@ -45,13 +46,14 @@ async def async_setup(hass, config):
                     pollenIDs.append(pollenID)
     else:
         pollenIDs = POLLEN_IDS.values()
-    _LOGGER.debug(f"Pollen IDs loaded from config: { pollenIDs }")
+    _LOGGER.debug(f"Pollen IDs loaded from config: {pollenIDs}")
 
+    
     hass.data[DOMAIN] = {CONF_CLIENT: Pollen_DK(regionIDs, pollenIDs)}
 
     # Add sensors
     hass.async_create_task(
-        hass.helpers.discovery.async_load_platform(CONF_PLATFORM, DOMAIN, conf, config)
+        async_load_platform(hass, CONF_PLATFORM, DOMAIN, conf, config)  # Tilføj 'config' som parameter
     )
 
     # Initialization was successful.


### PR DESCRIPTION
Fixes the issue #5 https://github.com/J-Lindvig/Pollen_DK/issues/5

Logger: homeassistant.helpers.frame
Kilde: helpers/frame.py:189
Første forekomst: 14.59.09 (2 forekomster)
Senest logget: 14.59.09

Detected that custom integration 'pollen_dk' accesses hass.helpers.discovery. This is deprecated and will stop working in Home Assistant 2025.5, it should be updated to import functions used from discovery directly at custom_components/pollen_dk/init.py, line 54: hass.helpers.discovery.async_load_platform(CONF_PLATFORM, DOMAIN, conf, config), please create a bug report at https://github.com/J-Lindvig/Pollen_DK/issues